### PR TITLE
Add rect method

### DIFF
--- a/src/stumpy_utils/rect.cr
+++ b/src/stumpy_utils/rect.cr
@@ -1,0 +1,19 @@
+
+module StumpyCore
+  class Canvas
+    def rect(x0, y0, x1, y1, stroke = RGBA::BLACK, fill = RGBA::BLACK)
+      # Fill
+      {x0, x1}.min.upto({x0, x1}.max) do |x|
+        {y0, y1}.min.upto({y0, y1}.max) do |y|
+          safe_set(x, y, fill)
+        end
+      end
+
+      # Stroke
+      line(x0, y0, x0, y1, stroke)
+      line(x0, y1, x1, y1, stroke)
+      line(x1, y1, x1, y0, stroke)
+      line(x1, y0, x0, y0, stroke)
+    end
+  end
+end


### PR DESCRIPTION
Closes #7 

It's tested and working, but I'm open to suggestions. It's based directly off of [`ChunkyPNG::Canvas::Drawing#rect`](https://www.rubydoc.info/gems/chunky_png/ChunkyPNG%2FCanvas%2FDrawing:rect).